### PR TITLE
Fixes the typecast error when attempting to call get(name, namespace)…

### DIFF
--- a/src/kube/resource_client.cr
+++ b/src/kube/resource_client.cr
@@ -169,6 +169,15 @@ module Kube
       ).as(T)
     end
 
+     # returns response body as a String instead of T
+     def get_as_string(name, namespace = @namespace)
+      @transport.request(
+        method: "GET",
+        path: path(name, namespace: namespace),
+        response_class: @resource_class
+      ).as(String)
+    end
+
     # raises [`Kube::Error::NotFound`] if resource is not found
     def get(resource : T) : T
       @transport.request(


### PR DESCRIPTION
Adds a `get_as_string` method to resource_client.cr to be used when the return type from k8s is String instead of the type of the resource (pods/log for example).