### PR TITLE
kalinon/issue12

### DIFF
--- a/src/kube/error.cr
+++ b/src/kube/error.cr
@@ -69,6 +69,14 @@ module Kube
       end
     end
 
+    class WatchClosed < API
+      getter resource_version : String?
+
+      def initialize(method, path, code : HTTP::Status, reason : String?, status = nil, @resource_version : String? = nil)
+        super(method, path, code, reason, status)
+      end
+    end
+
     macro define_api_errors
       {% for code, name in HTTP_STATUS_ERRORS %}
       class {{name}} < API

--- a/src/kube/resource_client.cr
+++ b/src/kube/resource_client.cr
@@ -240,7 +240,7 @@ module Kube
           rv = event.resource_version
           raise event if rv.nil?
           logger.debug &.emit "Watch channel closed, resuming", resource_version: rv, response_code: event.code
-          channel = watch(**nargs, resource_version: rv)
+          channel = watch(**nargs.merge({resource_version: rv}))
         elsif event.is_a?(Kube::Error::API)
           raise event
         else

--- a/src/kube/transport/requests.cr
+++ b/src/kube/transport/requests.cr
@@ -140,10 +140,12 @@ module Kube
                   response_channel.send(event)
                 rescue ex : Channel::ClosedError
                   io.close unless io.closed?
-                  break
+                  # Return to avoid raising the exception
+                  return
                 end
               end
             end
+            raise Kube::Error::API.new("GET", path, response.status, "Connection closed")
           else
             raise Kube::Error::API.new("GET", path, response.status, response.body)
           end

--- a/src/kube/watch_channel.cr
+++ b/src/kube/watch_channel.cr
@@ -1,10 +1,11 @@
 struct Kube::WatchChannel(T)
   @transport : Kube::Transport
   getter channel : Channel(::K8S::Kubernetes::WatchEvent(T) | Kube::Error::API)
+  getter resource_version : String?
 
-  def initialize(@transport)
+  def initialize(@transport, @resource_version = nil)
     @channel = Channel(::K8S::Kubernetes::WatchEvent(T) | Kube::Error::API).new
   end
 
-  delegate :close, :closed?, :receive, :receive?, to: :channel
+  delegate :close, :closed?, :receive, :receive?, :send, to: :channel
 end

--- a/src/kube/watch_channel.cr
+++ b/src/kube/watch_channel.cr
@@ -1,7 +1,7 @@
 struct Kube::WatchChannel(T)
   @transport : Kube::Transport
   getter channel : Channel(::K8S::Kubernetes::WatchEvent(T) | Kube::Error::API)
-  getter resource_version : String?
+  property resource_version : String?
 
   def initialize(@transport, @resource_version = nil)
     @channel = Channel(::K8S::Kubernetes::WatchEvent(T) | Kube::Error::API).new


### PR DESCRIPTION
PR fixes #12 

This fixes a bug where performing a watch would hang if the underlying socket is closed.

Further enhancements were added to enable bookmarks and auto-resume if needed. 

### Watching resources

Watching resources spawns a background fiber that will push `K8S::Kubernetes::WatchEvent`s for the resource onto the returned `Channel`. A `Kube::Error::WatchClosed` error will be returned if the watch stream has been closed. A `Kube::Error::API` error will be returned if an api error is encountered.

```crystal
resource_client = client.api("v1").resource("pods")
channel = resource_client.watch(resource_version: "4651")

while !channel.closed?
  event = channel.receive
  if event.is_a?(Kube::Error::WatchClosed)
    # Handle if the watch stream has been closed
  elsif event.is_a?(Kube::Error::API)
    # Handle error
  else
    pp event # => K8S::Kubernetes::WatchEvent(K8S::Api::Core::V1::Pod)
  end
end
```

The returned `Kube::Error::WatchClosed` error will contain the `resource_version` of the last event received before the watch stream was closed. This can be used to resume watching from the last known resource version:

```crystal
resource_client = client.api("v1").resource("pods")
channel = resource_client.watch

while !channel.closed?
  event = channel.receive
  if event.is_a?(Kube::Error::WatchClosed)
    # Restart the watch from the last known resource version
    channel = resource_client.watch(resource_version: event.resource_version)
  else
    pp event # => K8S::Kubernetes::WatchEvent(K8S::Api::Core::V1::Pod)
  end
end
```

You can also invoke the `watch` method with a block, which can automatically restart the watch from the last known resource version:

```crystal
resource_client.watch(auto_resume: true) do |event|
  obj = event.object.as(K8S::Api::Core::V1::Pod)
  Log.info { "#{event.type} #{obj.metadata.try &.name}" }
end
```